### PR TITLE
feat: support custom image

### DIFF
--- a/kubectl-enter
+++ b/kubectl-enter
@@ -15,6 +15,11 @@ IMAGE="alpine"
 SSHIMAGE="mutaz/ssh-client"
 POD="connector-$(env LC_CTYPE=C tr -dc a-z0-9 < /dev/urandom | head -c 6)"
 NAMESPACE=""
+
+if [ -n "${CUSTOM_IMAGE}" ]; then
+    IMAGE="${CUSTOM_IMAGE}"
+fi
+
 # Check the node
 kubectl get node "$NODE" >/dev/null || exit 1
 

--- a/kubectl-enter
+++ b/kubectl-enter
@@ -16,6 +16,8 @@ SSHIMAGE="mutaz/ssh-client"
 POD="connector-$(env LC_CTYPE=C tr -dc a-z0-9 < /dev/urandom | head -c 6)"
 NAMESPACE=""
 
+# Uncomment the next line if you would like to use your own image
+# CUSTOM_IMAGE=PUT-YOUR-IMAGE-NAME
 if [ -n "${CUSTOM_IMAGE}" ]; then
     IMAGE="${CUSTOM_IMAGE}"
 fi


### PR DESCRIPTION
- Some k8s clusters are deployed on the intranet and cannot access the docker.io image on the public network.